### PR TITLE
Delete `wrap/unwrap` for full balance as optional and unnecessary

### DIFF
--- a/src/usual/UsualM.sol
+++ b/src/usual/UsualM.sol
@@ -86,12 +86,6 @@ contract UsualM is ERC20PausableUpgradeable, ERC20PermitUpgradeable, IUsualM {
     }
 
     /// @inheritdoc IUsualM
-    function wrap(address recipient) external returns (uint256) {
-        address smartM_ = smartM();
-        return _wrap(smartM_, msg.sender, recipient, ISmartMLike(smartM_).balanceOf(msg.sender));
-    }
-
-    /// @inheritdoc IUsualM
     function wrapWithPermit(
         address recipient,
         uint256 amount,
@@ -111,11 +105,6 @@ contract UsualM is ERC20PausableUpgradeable, ERC20PermitUpgradeable, IUsualM {
     /// @inheritdoc IUsualM
     function unwrap(address recipient, uint256 amount) external onlyMatchingRole(USUAL_M_UNWRAP) returns (uint256) {
         return _unwrap(msg.sender, recipient, amount);
-    }
-
-    /// @inheritdoc IUsualM
-    function unwrap(address recipient) external onlyMatchingRole(USUAL_M_UNWRAP) returns (uint256) {
-        return _unwrap(msg.sender, recipient, balanceOf(msg.sender));
     }
 
     /* ============ Special Admin Functions ============ */

--- a/src/usual/interfaces/IUsualM.sol
+++ b/src/usual/interfaces/IUsualM.sol
@@ -48,13 +48,6 @@ interface IUsualM is IERC20Metadata {
     function wrap(address recipient, uint256 amount) external returns (uint256);
 
     /**
-     * @notice Wraps all the SmartM from the caller into UsualM for `recipient`.
-     * @param  recipient The account receiving the minted UsualM.
-     * @return           The amount of UsualM minted.
-     */
-    function wrap(address recipient) external returns (uint256);
-
-    /**
      * @notice Wraps `amount` SmartM from the caller into UsualM for `recipient`, using a permit.
      * @param  recipient The account receiving the minted UsualM.
      * @param  amount    The amount of SmartM deposited.
@@ -80,13 +73,6 @@ interface IUsualM is IERC20Metadata {
      * @return           The amount of SmartM withdrawn.
      */
     function unwrap(address recipient, uint256 amount) external returns (uint256);
-
-    /**
-     * @notice Unwraps all the UsualM from the caller into SmartM for `recipient`.
-     * @param  recipient The account receiving the withdrawn SmartM.
-     * @return           The amount of SmartM withdrawn.
-     */
-    function unwrap(address recipient) external returns (uint256);
 
     /**
      * @notice Adds an address to the blacklist.

--- a/test/integration/usual/TestBase.sol
+++ b/test/integration/usual/TestBase.sol
@@ -78,14 +78,6 @@ contract TestBase is Test {
         _usualM.wrap(recipient_, amount_);
     }
 
-    function _wrap(address account_, address recipient_) internal {
-        vm.prank(account_);
-        _smartMToken.approve(address(_usualM), type(uint256).max);
-
-        vm.prank(account_);
-        _usualM.wrap(recipient_);
-    }
-
     function _wrapWithPermitVRS(
         address account_,
         uint256 signerPrivateKey_,
@@ -103,11 +95,6 @@ contract TestBase is Test {
     function _unwrap(address account_, address recipient_, uint256 amount_) internal {
         vm.prank(account_);
         _usualM.unwrap(recipient_, amount_);
-    }
-
-    function _unwrap(address account_, address recipient_) internal {
-        vm.prank(account_);
-        _usualM.unwrap(recipient_);
     }
 
     function _set(bytes32 key_, bytes32 value_) internal {

--- a/test/integration/usual/UsualM.t.sol
+++ b/test/integration/usual/UsualM.t.sol
@@ -48,7 +48,7 @@ contract UsualMIntegrationTests is TestBase {
 
         // Claim yield by unwrapping
         vm.prank(_alice);
-        _usualM.unwrap(_alice);
+        _usualM.unwrap(_alice, amount);
 
         // Check balances of UsualM and Alice after unwrapping
         assertEq(_usualM.balanceOf(_alice), 0);

--- a/test/unit/usual/UsualM.t.sol
+++ b/test/unit/usual/UsualM.t.sol
@@ -68,7 +68,7 @@ contract UsualMUnitTests is Test {
     /* ============ wrap ============ */
     function test_wrap_wholeBalance() external {
         vm.prank(_alice);
-        _usualM.wrap(_alice);
+        _usualM.wrap(_alice, 10e6);
 
         assertEq(_smartMToken.balanceOf(_alice), 0);
         assertEq(_smartMToken.balanceOf(address(_usualM)), 10e6);
@@ -120,7 +120,7 @@ contract UsualMUnitTests is Test {
         assertEq(_usualM.balanceOf(_alice), 10e6);
 
         vm.prank(_alice);
-        _usualM.unwrap(_alice);
+        _usualM.unwrap(_alice, 10e6);
 
         assertEq(_smartMToken.balanceOf(_alice), 10e6);
         assertEq(_smartMToken.balanceOf(address(_usualM)), 0);
@@ -139,7 +139,7 @@ contract UsualMUnitTests is Test {
         vm.expectRevert(IUsualM.NotAuthorized.selector);
 
         vm.prank(_other);
-        _usualM.unwrap(_other);
+        _usualM.unwrap(_other, 10e6);
     }
 
     /* ============ pause ============ */
@@ -165,7 +165,7 @@ contract UsualMUnitTests is Test {
 
     function test_pause_unwrap() external {
         vm.prank(_alice);
-        _usualM.wrap(_alice);
+        _usualM.wrap(_alice, 10e6);
 
         vm.prank(_pauser);
         _usualM.pause();
@@ -173,7 +173,7 @@ contract UsualMUnitTests is Test {
         vm.expectRevert(Pausable.EnforcedPause.selector);
 
         vm.prank(_alice);
-        _usualM.unwrap(_bob);
+        _usualM.unwrap(_bob, 10e6);
     }
 
     function test_pause_unauthorized() external {


### PR DESCRIPTION
Changes: 
delete `wrap/unwrap` for full balance. These methods are not currently required by Usual extension