### PR TITLE
Optional - remove `getWrappableAmount`

### DIFF
--- a/src/usual/UsualM.sol
+++ b/src/usual/UsualM.sol
@@ -226,14 +226,6 @@ contract UsualM is ERC20PausableUpgradeable, ERC20PermitUpgradeable, IUsualM {
         return $.isBlacklisted[account];
     }
 
-    /// @inheritdoc IUsualM
-    function getWrappableAmount(uint256 amount) external view returns (uint256) {
-        uint256 totalSupply_ = totalSupply();
-        uint256 mintCap_ = mintCap();
-
-        return _min(amount, mintCap_ > totalSupply_ ? mintCap_ - totalSupply_ : 0);
-    }
-
     /* ============ Internal Interactive Functions ============ */
 
     /**
@@ -284,11 +276,6 @@ contract UsualM is ERC20PausableUpgradeable, ERC20PermitUpgradeable, IUsualM {
         if ($.isBlacklisted[from] || $.isBlacklisted[to]) revert Blacklisted();
 
         ERC20PausableUpgradeable._update(from, to, amount);
-    }
-
-    /// @dev Compares two uint256 values and returns the lesser one.
-    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a < b ? a : b;
     }
 
     /// @dev Converts a uint256 to a uint96, reverting if the conversion without loss is not possible.

--- a/src/usual/interfaces/IUsualM.sol
+++ b/src/usual/interfaces/IUsualM.sol
@@ -131,7 +131,4 @@ interface IUsualM is IERC20Metadata {
 
     /// @notice Returns the Mint Cap amount.
     function mintCap() external view returns (uint256);
-
-    /// @notice Returns the available wrappable amount for the current values of `mintCap` and `totalSupply`.
-    function getWrappableAmount(uint256 amount) external view returns (uint256);
 }

--- a/test/unit/usual/UsualM.t.sol
+++ b/test/unit/usual/UsualM.t.sol
@@ -445,25 +445,6 @@ contract UsualMUnitTests is Test {
         _usualM.setMintCap(100e6);
     }
 
-    /* ============ wrappable amount ============ */
-    function test_getWrappableAmount() external {
-        vm.prank(_mintCapAllocator);
-        _usualM.setMintCap(100e6);
-
-        // Initially, wrappable amount should be the full mint cap
-        assertEq(_usualM.getWrappableAmount(100e6), 100e6);
-
-        // Wrap some tokens
-        vm.prank(_alice);
-        _usualM.wrap(_alice, 10e6);
-
-        // Check wrappable amount with amount exceeding difference between mint cap and total supply
-        assertEq(_usualM.getWrappableAmount(100e6), 90e6);
-
-        // Check wrappable amount with amount less than difference between mint cap and total supply
-        assertEq(_usualM.getWrappableAmount(20e6), 20e6);
-    }
-
     /* ============ utils ============ */
     function _resetInitializerImplementation(address implementation) internal {
         // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) & ~bytes32(uint256(0xff))


### PR DESCRIPTION
Optional suggestion to remove `getWrappableAmount` method as there is no clarity if it is actually needed for this integration.  